### PR TITLE
Reduce HttpLogMessageFactory allocation

### DIFF
--- a/benchmark/raccoonLog.Benchmarks/MessageFactoryBenchmarks.cs
+++ b/benchmark/raccoonLog.Benchmarks/MessageFactoryBenchmarks.cs
@@ -1,6 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using raccoonLog.Mocking;

--- a/benchmark/raccoonLog.Benchmarks/Program.cs
+++ b/benchmark/raccoonLog.Benchmarks/Program.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 
 namespace raccoonLog.Benchmarks
 {

--- a/src/raccoonLog/Handlers/HttpMessageLogBodyReader.cs
+++ b/src/raccoonLog/Handlers/HttpMessageLogBodyReader.cs
@@ -10,9 +10,9 @@ namespace raccoonLog.Handlers
 {
     public class HttpMessageLogBodyReader
     {
-        private readonly List<string> _ignoredContentTypes;
+        private readonly HashSet<string> _ignoredContentTypes;
 
-        public HttpMessageLogBodyReader(List<string> ignoredContentTypes)
+        public HttpMessageLogBodyReader(HashSet<string> ignoredContentTypes)
         {
             _ignoredContentTypes = ignoredContentTypes;
         }

--- a/src/raccoonLog/HttpLogSensitiveDataOptions.cs
+++ b/src/raccoonLog/HttpLogSensitiveDataOptions.cs
@@ -5,7 +5,7 @@ namespace raccoonLog
 {
     public class HttpMessageLogSensitiveDataOptions
     {
-        public List<string> Headers { get; set; } = new List<string>();
+        public HashSet<string> Headers { get; set; } = new HashSet<string>();
 
     }
 
@@ -20,11 +20,11 @@ namespace raccoonLog
             Headers.Add(HeaderNames.ProxyAuthorization);
         }
 
-        public List<string> Parameters { get; set; } = new List<string>();
+        public HashSet<string> Parameters { get; set; } = new HashSet<string>();
 
-        public List<string> Cookies { get; set; } = new List<string>();
+        public HashSet<string> Cookies { get; set; } = new HashSet<string>();
 
-        public List<string> Forms { get; set; } = new List<string>();
+        public HashSet<string> Forms { get; set; } = new HashSet<string>();
     }
 
     public class HttpResponseLogSensitiveDataOptions : HttpMessageLogSensitiveDataOptions

--- a/src/raccoonLog/HttpLoggingBuilderExtensions.cs
+++ b/src/raccoonLog/HttpLoggingBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace raccoonLog
             Action<RaccoonLogHttpOptions> configureOptions)
         {
             services.Configure(configureOptions);
-
+            
             services.AddHttpContextAccessor();
 
             services.AddScoped<IDataProtector, DataProtector>();

--- a/src/raccoonLog/HttpLoggingProvider.cs
+++ b/src/raccoonLog/HttpLoggingProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Diagnostics;

--- a/src/raccoonLog/HttpRequestLog.cs
+++ b/src/raccoonLog/HttpRequestLog.cs
@@ -13,6 +13,7 @@ namespace raccoonLog
             Cookies = cookies;
         }        
         
+        
         public UrlLog Url { get; private set; }
 
         public string Method { get; private set; }
@@ -22,7 +23,6 @@ namespace raccoonLog
         public string? ContentType { get; private set; }
 
         public IReadOnlyList<KeyValuePair<string, string>> Headers { get; set; }
-
 
         public IReadOnlyList<KeyValuePair<string, string>> Cookies { get; private set; }
 

--- a/src/raccoonLog/LogContext.cs
+++ b/src/raccoonLog/LogContext.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 
 namespace raccoonLog
 {

--- a/src/raccoonLog/RaccoonLogHttpOptions.cs
+++ b/src/raccoonLog/RaccoonLogHttpOptions.cs
@@ -64,9 +64,9 @@ namespace raccoonLog
 
     public abstract class RaccoonLogHttpMessageOptions
     {
-        public List<string> IgnoreHeaders { get; set; } = new List<string>();
+        public HashSet<string> IgnoreHeaders { get; set; } = new HashSet<string>();
 
-        public List<string> IgnoreContentTypes { get; set; } = new List<string>();
+        public HashSet<string> IgnoreContentTypes { get; set; } = new HashSet<string>();
     }
 
     public class RaccoonLogHttpResponseOptions : RaccoonLogHttpMessageOptions

--- a/src/raccoonLog/UrlLog.cs
+++ b/src/raccoonLog/UrlLog.cs
@@ -6,6 +6,8 @@ namespace raccoonLog
 {
     public class UrlLog
     {
+        public static UrlLog Default => new UrlLog(80,"/","localhost","http",new List<KeyValuePair<string, string>>());
+        
         public UrlLog(int port, string path, string host, string scheme,
             IReadOnlyList<KeyValuePair<string, string>> parameters)
         {
@@ -15,6 +17,7 @@ namespace raccoonLog
             Scheme = scheme;
             Parameters = parameters;
         }
+        
 
         public int Port { get; private set; }
 
@@ -30,7 +33,9 @@ namespace raccoonLog
 
         public override string ToString()
         {
-            return new UriBuilder(Scheme, Host, Port, Path, QueryString.Create(Parameters).Value).Uri.ToString();
+            var query = QueryString.Create(Parameters).Value;
+            
+            return new UriBuilder(Scheme, Host, Port, Path, query).Uri.ToString();
         }
     }
 }

--- a/test/raccoonLog.IntegrationTests/BaseStartup.cs
+++ b/test/raccoonLog.IntegrationTests/BaseStartup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using raccoonLog.IntegrationTests.Domain;
 
 namespace raccoonLog.IntegrationTests
 {

--- a/test/raccoonLog.IntegrationTests/Domain/Address.cs
+++ b/test/raccoonLog.IntegrationTests/Domain/Address.cs
@@ -1,4 +1,4 @@
-﻿namespace raccoonLog.IntegrationTests
+﻿namespace raccoonLog.IntegrationTests.Domain
 {
     public class Address
     {

--- a/test/raccoonLog.IntegrationTests/Domain/Gender.cs
+++ b/test/raccoonLog.IntegrationTests/Domain/Gender.cs
@@ -1,4 +1,4 @@
-﻿namespace raccoonLog.IntegrationTests
+﻿namespace raccoonLog.IntegrationTests.Domain
 {
     public enum Gender
     {

--- a/test/raccoonLog.IntegrationTests/Domain/Person.cs
+++ b/test/raccoonLog.IntegrationTests/Domain/Person.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace raccoonLog.IntegrationTests
+namespace raccoonLog.IntegrationTests.Domain
 {
     public class Person
     {

--- a/test/raccoonLog.IntegrationTests/FileStore/FileStoreTests.cs
+++ b/test/raccoonLog.IntegrationTests/FileStore/FileStoreTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using raccoonLog.IntegrationTests.Domain;
 using raccoonLog.Stores.File;
 using Xunit;
 using JsonSerializer = System.Text.Json.JsonSerializer;

--- a/test/raccoonLog.UnitTests/Functional/HttpLoggingTests.cs
+++ b/test/raccoonLog.UnitTests/Functional/HttpLoggingTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
+using raccoonLog.Mocking;
 using Xunit;
 
 namespace raccoonLog.UnitTests.Functional

--- a/test/raccoonLog.UnitTests/Handlers/HttpRequestLogHandlerTests.cs
+++ b/test/raccoonLog.UnitTests/Handlers/HttpRequestLogHandlerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Moq;
 using raccoonLog.Handlers;
+using raccoonLog.Mocking;
 using Xunit;
 
 namespace raccoonLog.UnitTests.Handlers
@@ -18,7 +19,7 @@ namespace raccoonLog.UnitTests.Handlers
             var handler = new DefaultHttpRequestLogHandler(factory.Object, formContentHandler.Object, DefaultOptions.Default);
             var context = new DefaultHttpContext();
 
-            factory.Setup(f => f.Create(context.Request)).Returns(new HttpRequestLog(null!, null!, null, null!, null!));
+            factory.Setup(f => f.Create(context.Request)).Returns(new HttpRequestLog(UrlLog.Default, null!, null, null!, null!));
 
             context.Features.Set<IFormFeature>(new FakeForm());
             context.Features.Set<IHttpRequestFeature>(new FakeHttpRequest());
@@ -36,7 +37,7 @@ namespace raccoonLog.UnitTests.Handlers
             var formContentHandler = new Mock<IHttpRequestLogFormHandler>();
             var handler = new DefaultHttpRequestLogHandler(factory.Object, formContentHandler.Object, DefaultOptions.Default);
             var context = new DefaultHttpContext();
-            var logMessage = new HttpRequestLog(null, null, null, null, null);
+            var logMessage = new HttpRequestLog(UrlLog.Default, null, null, null, null);
             var content = "The Request Body Content!";
 
             factory.Setup(f => f.Create(context.Request)).Returns(logMessage);

--- a/test/raccoonLog.UnitTests/Handlers/HttpResponseLogHandlerTests.cs
+++ b/test/raccoonLog.UnitTests/Handlers/HttpResponseLogHandlerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Moq;
 using raccoonLog.Handlers;
+using raccoonLog.Mocking;
 using Xunit;
 
 namespace raccoonLog.UnitTests.Handlers

--- a/test/raccoonLog.UnitTests/HttpLogMessageBodyTests.cs
+++ b/test/raccoonLog.UnitTests/HttpLogMessageBodyTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Options;
 using Moq;
 using raccoonLog.Handlers;
+using raccoonLog.Mocking;
 using Xunit;
 
 namespace raccoonLog.UnitTests
@@ -24,7 +25,7 @@ namespace raccoonLog.UnitTests
 
             context.Features.Set<IFormFeature>(FakeForm.Value);
 
-            var requestLog = new HttpRequestLog(null!, null!, null, null!, null!);
+            var requestLog = new HttpRequestLog(UrlLog.Default, null!, null, null!, null!);
 
             await handler.Handle(context.Request, requestLog);
 
@@ -52,7 +53,7 @@ namespace raccoonLog.UnitTests
 
             context.Features.Set<IFormFeature>(FakeForm.Value);
 
-            var requestLog = new HttpRequestLog(null, null, null, null, null);
+            var requestLog = new HttpRequestLog(UrlLog.Default, null, null, null, null);
 
             await handler.Handle(context.Request, requestLog);
 

--- a/test/raccoonLog.UnitTests/HttpLogMessageFactoryTests.cs
+++ b/test/raccoonLog.UnitTests/HttpLogMessageFactoryTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using raccoonLog.Mocking;
 using Xunit;
 
 namespace raccoonLog.UnitTests
@@ -77,6 +78,8 @@ namespace raccoonLog.UnitTests
 
             Assert.NotEqual(requestLog.Headers.First(h => h.Key == "X-Custom").Value, context.Request.Headers["X-Custom"].ToString());
             Assert.NotEqual(requestLog.Cookies.First(h => h.Key == "auth_token").Value, context.Request.Cookies["auth_token"]);
+            Assert.NotEqual(requestLog.Url.Parameters.First(h => h.Key == "name").Value, context.Request.Query["name"].ToString());
+
         }
 
         [Fact]

--- a/test/raccoonLog.UnitTests/HttpMessageLogBodyReaderTests.cs
+++ b/test/raccoonLog.UnitTests/HttpMessageLogBodyReaderTests.cs
@@ -16,7 +16,7 @@ namespace raccoonLog.UnitTests
         {
             var bodyStream = new MemoryStream();
             var json = "{\"name\":\"my_name\"}";
-            var reader = new HttpMessageLogBodyReader(new List<string>());
+            var reader = new HttpMessageLogBodyReader(new HashSet<string>());
 
             bodyStream.Write(Encoding.UTF8.GetBytes(json));
 
@@ -30,7 +30,7 @@ namespace raccoonLog.UnitTests
         {
             var bodyStream = new MemoryStream();
 
-            var reader = new HttpMessageLogBodyReader(new List<string>());
+            var reader = new HttpMessageLogBodyReader(new HashSet<string>());
 
             var body = await reader.ReadAsync(bodyStream, MediaTypeNames.Application.Json, 0);
 
@@ -42,7 +42,7 @@ namespace raccoonLog.UnitTests
         {
             var bodyStream = new MemoryStream();
 
-            var ignoredContents = new List<string>() { MediaTypeNames.Text.Plain };
+            var ignoredContents = new HashSet<string>() { MediaTypeNames.Text.Plain };
 
             var reader = new HttpMessageLogBodyReader(ignoredContents);
 


### PR DESCRIPTION
## Before
```
|            Method |     Mean |      Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|-----------:|----------:|-------:|------:|------:|----------:|
|  CreateRequestLog | 6.927 μs | 16.3183 μs | 0.8945 μs | 2.3651 |     - |     - |   7.27 KB |
| CreateResponseLog | 2.740 μs |  0.2114 μs | 0.0116 μs | 1.9684 |     - |     - |   6.03 KB |
```

## After

```
|            Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|-------:|------:|------:|----------:|
|  CreateRequestLog | 4.045 μs | 0.8829 μs | 0.0484 μs | 1.0147 |     - |     - |   3.12 KB |
| CreateResponseLog | 1.644 μs | 1.7368 μs | 0.0952 μs | 0.7133 |     - |     - |   2.19 KB |
```